### PR TITLE
add sync option to cache annotation and remove redundant process

### DIFF
--- a/src/main/java/io/github/yuizho/springbootissuesummary/infrastructure/rest/adopters/IssuesRestFetcher.java
+++ b/src/main/java/io/github/yuizho/springbootissuesummary/infrastructure/rest/adopters/IssuesRestFetcher.java
@@ -25,7 +25,7 @@ public class IssuesRestFetcher implements IssuesFetcher {
     @Autowired
     private RestApiClient apiClient;
 
-    @Cacheable(value = DOMAIN_NAME)
+    @Cacheable(value = DOMAIN_NAME, sync = true)
     @Override
     public Issues fetchIssues() {
         try {

--- a/src/main/java/io/github/yuizho/springbootissuesummary/infrastructure/rest/jobs/IssuesRestCacheJob.java
+++ b/src/main/java/io/github/yuizho/springbootissuesummary/infrastructure/rest/jobs/IssuesRestCacheJob.java
@@ -38,8 +38,7 @@ public class IssuesRestCacheJob implements CacheJob {
             }
             issuesCache.clear();
             // get IssuesRestFetcher
-            Issues issues= issuesFetchers.get(IssuesFetcher.DOMAIN_NAME + DATA_SOURCE_TYPE_REST).fetchIssues();
-            issuesCache.put(SimpleKey.EMPTY, issues);
+            Issues issues = issuesFetchers.get(IssuesFetcher.DOMAIN_NAME + DATA_SOURCE_TYPE_REST).fetchIssues();
         }
     }
 }


### PR DESCRIPTION
ジョブ内でIssuesRestFetcher#fetchIssuesを読んでもキャッシュが更新されなかったため、Cache#putで更新していたが、@Cacheableに```sync=true```を設定すればCache#putなしで更新されるみたい。

```sync=true```をつけないと異なるthread間で同期がとられないということだと思われる。
https://qiita.com/kazuki43zoo/items/43cea4b36822b58c0562